### PR TITLE
Fix history nullified for Office.js to not break modern applications

### DIFF
--- a/dist/custom-functions-runtime.debug.js
+++ b/dist/custom-functions-runtime.debug.js
@@ -1965,11 +1965,6 @@ OSF._OfficeAppFactory = (function OSF__OfficeAppFactory() {
         window.prompt = function OSF__OfficeAppFactory_initialize$prompt(message, defaultvalue) {
             throw new Error('Function window.prompt is not supported.');
         };
-        var isOutlookAndroid = _hostInfo.hostType == "outlook" && _hostInfo.hostPlatform == "android";
-        if (!isOutlookAndroid) {
-            window.history.replaceState = null;
-            window.history.pushState = null;
-        }
     };
     initialize();
     if (window.addEventListener) {

--- a/dist/office.debug.js
+++ b/dist/office.debug.js
@@ -1989,11 +1989,6 @@ OSF._OfficeAppFactory = (function OSF__OfficeAppFactory() {
         window.prompt = function OSF__OfficeAppFactory_initialize$prompt(message, defaultvalue) {
             throw new Error('Function window.prompt is not supported.');
         };
-        var isOutlookAndroid = _hostInfo.hostType == "outlook" && _hostInfo.hostPlatform == "android";
-        if (!isOutlookAndroid) {
-            window.history.replaceState = null;
-            window.history.pushState = null;
-        }
     };
     initialize();
     if (window.addEventListener) {


### PR DESCRIPTION
We need thoses lines removed from office.js to avoid shady workarounds. This is blocking for most modern applications and routers (Next/Nuxt/Vue/React/Svelt).

Plus, it is not mentionned anywhere that Office.js nullify those, and it can be very misleading as you can see:

- https://github.com/OfficeDev/office-js/issues/429
- https://github.com/OfficeDev/office-js/issues/655
- https://github.com/OfficeDev/office-js/issues/1198
- https://github.com/OfficeDev/office-js/issues/1344
- https://github.com/OfficeDev/office-js/issues/2108

If this PR is not merged, please consider at least fixing it on your side **OR** mentioning why it is done (IE 11 compatibility I presume), and an official workaround, since this can be very tricky to spot.

@Rick-Kirkham Maybe you can help on this side ?
