### PR TITLE
Add general discussions link to issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -5,4 +5,4 @@ contact_links:
     about: To request a new feature in Office.js or the Office developer platform, please post your idea to the Microsoft 365 Developer Platform Tech Community.
   - name: General discussions
     url: https://github.com/OfficeDev/office-js/discussions
-    about: For general discussions about Office.js, please use the GitHub Discussions forum.
+    about: For general questions and other discussions about Office.js, please use the GitHub Discussions forum.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,6 @@ contact_links:
   - name: Feature request
     url: https://techcommunity.microsoft.com/category/microsoft365/ideas/microsoft365developerplatform
     about: To request a new feature in Office.js or the Office developer platform, please post your idea to the Microsoft 365 Developer Platform Tech Community.
+  - name: General discussions
+    url: https://github.com/OfficeDev/office-js/discussions
+    about: For general discussions about Office.js, please use the GitHub Discussions forum.


### PR DESCRIPTION
Add a section in the new issue creation template to use the discussion forum for general discussion type of issues like the following: https://github.com/OfficeDev/office-js/issues/5627