### PR TITLE
docs: clarify issue vs documentation routing

### DIFF
--- a/.github/ISSUE_TEMPLATE/how-to-question.md
+++ b/.github/ISSUE_TEMPLATE/how-to-question.md
@@ -11,11 +11,11 @@ assignees: ''
 ## Post how-to questions about your code on Microsoft Q&A
 
 We have several forums where you can ask the developer community questions about your code. Try one of the following forums to ask technical questions about:
-- [Developing Office Add-ins for Word, Excel, PowerPoint, Outlook, Project, Visio, and OneNote](https://docs.microsoft.com/answers/topics/office-addins-dev.html)
-- [Access programming in Office](https://docs.microsoft.com/answers/topics/office-access-dev.html)
-- [Developing COM or VSTO Add-ins for Office](https://docs.microsoft.com/answers/topics/office-vsto-com-dev.html)
-- [Office JavaScript API](https://docs.microsoft.com/answers/topics/office-js-dev.html)
-- [SharePoint and OneDrive development](https://docs.microsoft.com/answers/topics/sharepoint-dev.html)
-- [Deploying and publishing Office or SharePoint apps to AppSource](https://docs.microsoft.com/answers/topics/microsoft-365-apps-publishing-dev.html)
+- [Developing Office Add-ins for Word, Excel, PowerPoint, Outlook, Project, Visio, and OneNote](https://learn.microsoft.com/answers/topics/office-addins-dev.html)
+- [Access programming in Office](https://learn.microsoft.com/answers/topics/office-access-dev.html)
+- [Developing COM or VSTO Add-ins for Office](https://learn.microsoft.com/answers/topics/office-vsto-com-dev.html)
+- [Office JavaScript API](https://learn.microsoft.com/answers/topics/office-js-dev.html)
+- [SharePoint and OneDrive development](https://learn.microsoft.com/answers/topics/sharepoint-dev.html)
+- [Deploying and publishing Office or SharePoint apps to AppSource](https://learn.microsoft.com/answers/topics/microsoft-365-apps-publishing-dev.html)
 
-For additional information about JavaScript programming, see the [JavaScript at Microsoft](https://docs.microsoft.com/javascript/) community hub.
+For additional information about JavaScript programming, see the [JavaScript at Microsoft](https://learn.microsoft.com/javascript/) community hub.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Contributing
+
+Thanks for your interest in Office.js and the Office Add-ins platform.
+
+This repository is **primarily for reporting product bugs** in the Office JavaScript APIs. Please use the routes below so issues reach the right audience quickly.
+
+| Topic | Where to go |
+| --- | --- |
+| Bug in Office.js / Office Add-ins platform behavior | [GitHub Issues](https://github.com/OfficeDev/office-js/issues) in this repository (use the **Bug report** template) |
+| How-to / usage questions | [Stack Overflow](https://stackoverflow.com/questions/tagged/office-js) (`office-js`) or [Microsoft Q&A (Office JavaScript API)](https://learn.microsoft.com/answers/topics/office-js-dev.html) |
+| Documentation feedback (Learn articles, samples, typos) | Use **feedback** on the relevant [Office Add-ins documentation](https://learn.microsoft.com/office/dev/add-ins/) page |
+| Feature requests | [Microsoft 365 Developer Platform Tech Community](https://aka.ms/m365dev-suggestions) |
+| General discussion | [GitHub Discussions](https://github.com/OfficeDev/office-js/discussions) |
+
+## Pull requests
+
+This repository hosts issue tracking and CDN-oriented guidance. The npm package here is no longer officially supported; add-ins should load Office.js from the CDN as described in the [README](README.md). Documentation content for Learn lives in separate docs repositories—prefer Learn page feedback for article fixes.
+
+## Code of Conduct
+
+This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ This GitHub repository is primarily used to report issues found in the Office Ja
 
 ## Report issues
 
+See also [CONTRIBUTING.md](CONTRIBUTING.md) for where to file bugs, how-to questions, documentation feedback, and feature requests.
+
+
 If you believe you've found an issue (bug) with the Office JavaScript APIs, please visit the [issues tab](https://github.com/OfficeDev/office-js/issues) of this repo. If your issue is already reported, consider adding additional context or reproduction steps. Otherwise, select **New issue**, choose **Bug report**, and provide as much detail as possible. A member of our team will respond within 1-2 business days.
 
 > [!NOTE]
@@ -19,7 +22,9 @@ Requests for new platform features should be raised at the [Microsoft 365 Develo
 
 ### Other questions
 
-Questions about developing add-ins and how to use the APIs should be raised on [Stack Overflow](https://stackoverflow.com/questions/tagged/office-js) with the "office-js" tag or on [Microsoft Q&A](https://learn.microsoft.com/answers/tags/321/office-development) with the "Office Development" tag. These locations are monitored by a community of experts, which includes members of our product team. They'll review questions and provide assistance as they're able.
+Questions about developing add-ins and how to use the APIs should be raised on [Stack Overflow](https://stackoverflow.com/questions/tagged/office-js) with the "office-js" tag or on [Microsoft Q&A (Office JavaScript API)](https://learn.microsoft.com/answers/topics/office-js-dev.html). These locations are monitored by a community of experts, which includes members of our product team. They'll review questions and provide assistance as they're able.
+
+Documentation feedback (typos, missing samples, or Learn article issues) should be submitted with the feedback controls on the relevant [Office Add-ins documentation](https://learn.microsoft.com/office/dev/add-ins/) page, not as API bugs in this repository.
 
 ## Reference Office.js from the CDN
 


### PR DESCRIPTION
## Summary
Adds a small CONTRIBUTING guide so newcomers know this repo is primarily for Office.js product bugs, and where to send how-to questions, Learn documentation feedback, and feature requests. Updates the how-to issue template to use `learn.microsoft.com` instead of legacy `docs.microsoft.com` links.

## Changes
- New `CONTRIBUTING.md` routing table
- `README.md`: link to CONTRIBUTING; clarify docs feedback path; tighten Microsoft Q&A link
- `.github/ISSUE_TEMPLATE/how-to-question.md`: docs.microsoft.com → learn.microsoft.com

## Test plan
- [ ] Click through CONTRIBUTING / README links
- [ ] Confirm issue template links resolve
- [ ] No Office login required

Docs-only.
